### PR TITLE
fix: Correct deployment configuration for Render

### DIFF
--- a/daily_management/daily_management/wsgi.py
+++ b/daily_management/daily_management/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "daily_management.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "daily_management.daily_management.settings")
 
 application = get_wsgi_application()

--- a/render.yaml
+++ b/render.yaml
@@ -22,7 +22,7 @@ services:
     # The command to build your app
     buildCommand: "./build.sh"
     # The command to start your app
-    startCommand: "gunicorn daily_management.wsgi"
+    startCommand: "gunicorn daily_management.daily_management.wsgi"
     # Environment variables for your app
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
This commit fixes two issues that caused deployment failures on Render:

1.  The `DJANGO_SETTINGS_MODULE` path in `wsgi.py` was incorrect due to the nested project structure. It has been updated to point to `daily_management.daily_management.settings`.

2.  The `startCommand` in `render.yaml` was also incorrect. It has been updated to `gunicorn daily_management.daily_management.wsgi` to match the correct module path.