### PR TITLE
I've specified the free plan for the web service in your `render.yaml…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,7 @@ services:
   - type: web
     name: daily-management-app
     env: python
+    plan: free
     buildCommand: "./build.sh"
     startCommand: "gunicorn daily_management.daily_management.wsgi"
     envVars:


### PR DESCRIPTION
…` file. This ensures that the free instance type is used, preventing automatic selection of a paid plan.