### PR TITLE
feat: Implement weather data auto-fill

### DIFF
--- a/records/templates/records/record_form.html
+++ b/records/templates/records/record_form.html
@@ -9,9 +9,73 @@
     <h1>記録フォーム</h1>
     <form method="post">
         {% csrf_token %}
-        {{ form.as_p }}
+
+        <p>
+            <label for="id_date">日付:</label>
+            {{ form.date }}
+            <button type="button" id="fetch-weather-btn">天気データを取得</button>
+            <span id="weather-status"></span>
+        </p>
+        <p><label for="id_weather">天気:</label>{{ form.weather }}</p>
+        <p><label for="id_max_pressure">最高気圧 (hPa):</label>{{ form.max_pressure }}</p>
+        <p><label for="id_min_pressure">最低気圧 (hPa):</label>{{ form.min_pressure }}</p>
+        <p><label for="id_max_temperature">最高気温 (°C):</label>{{ form.max_temperature }}</p>
+        <p><label for="id_min_temperature">最低気温 (°C):</label>{{ form.min_temperature }}</p>
+        <p><label for="id_humidity">湿度 (%):</label>{{ form.humidity }}</p>
+        <p><label for="id_pollen">花粉状況:</label>{{ form.pollen }}</p>
+        <p><label for="id_pm25">PM2.5飛散状況:</label>{{ form.pm25 }}</p>
+        <p><label for="id_my_mood">自分の機嫌:</label>{{ form.my_mood }}</p>
+        <p><label for="id_wife_mood">妻の機嫌:</label>{{ form.wife_mood }}</p>
+        <p><label for="id_headache_medicine">頭痛薬接種:</label>{{ form.headache_medicine }}</p>
+        <p><label for="id_mishap">失態の有無:</label>{{ form.mishap }}</p>
+        <p><label for="id_diary">日記:</label><br>{{ form.diary }}</p>
+
         <button type="submit">保存</button>
     </form>
     <a href="{% url 'record_list' %}">記録一覧に戻る</a>
+
+    <script>
+        document.getElementById('fetch-weather-btn').addEventListener('click', () => {
+            const dateInput = document.getElementById('id_date');
+            const statusSpan = document.getElementById('weather-status');
+            const date = dateInput.value;
+
+            if (!date) {
+                statusSpan.textContent = '日付を選択してください。';
+                return;
+            }
+
+            statusSpan.textContent = '天気データを取得中...';
+
+            fetch(`/api/get-weather/?date=${date}`)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    if (data.error) {
+                        statusSpan.textContent = `エラー: ${data.error}`;
+                        return;
+                    }
+
+                    // Populate form fields
+                    document.getElementById('id_weather').value = data.weather || '';
+                    document.getElementById('id_max_temperature').value = data.max_temperature || '';
+                    document.getElementById('id_min_temperature').value = data.min_temperature || '';
+                    document.getElementById('id_humidity').value = data.humidity || '';
+                    // Note: API provides one pressure value, so we set both fields to the same value.
+                    document.getElementById('id_max_pressure').value = data.pressure || '';
+                    document.getElementById('id_min_pressure').value = data.pressure || '';
+
+                    statusSpan.textContent = 'データを取得しました。';
+                })
+                .catch(e => {
+                    console.error('Fetch error:', e);
+                    statusSpan.textContent = 'データの取得に失敗しました。';
+                });
+        });
+    </script>
 </body>
 </html>

--- a/records/urls.py
+++ b/records/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('<int:pk>/edit/', views.update_record, name='update_record'),
     path('<int:pk>/delete/', views.delete_record, name='delete_record'),
     path('visualize/', views.data_visualization, name='data_visualization'),
+    path('api/get-weather/', views.get_weather_data, name='get_weather_data'),
 ]

--- a/records/views.py
+++ b/records/views.py
@@ -3,6 +3,10 @@ from .models import DailyRecord
 from .forms import DailyRecordForm
 from django.contrib import messages
 import json
+import os
+import requests
+from django.http import JsonResponse
+from datetime import datetime, date, timedelta
 
 def index(request):
     return render(request, 'records/index.html')
@@ -74,3 +78,82 @@ def data_visualization(request):
     }
 
     return render(request, 'records/visualization.html', context)
+
+def get_weather_data(request):
+    target_date_str = request.GET.get('date')
+    if not target_date_str:
+        return JsonResponse({'error': '日付が指定されていません。'}, status=400)
+
+    try:
+        target_date = datetime.strptime(target_date_str, '%Y-%m-%d').date()
+    except ValueError:
+        return JsonResponse({'error': '無効な日付形式です。YYYY-MM-DD形式で指定してください。'}, status=400)
+
+    # Coordinates for Imabari, Ehime, Japan
+    lat = 34.0663
+    lon = 132.9949
+
+    api_key = os.environ.get('OPENWEATHER_API_KEY')
+    if not api_key:
+        return JsonResponse({'error': 'APIキーが設定されていません。'}, status=500)
+
+    # Decide whether to use historical or forecast API
+    today = date.today()
+    if target_date < today:
+        # Historical data request
+        # Note: OneCall 3.0 historical is not free for more than a few days back.
+        # This implementation assumes we are fetching recent past data.
+        dt = int(datetime.combine(target_date, datetime.min.time()).timestamp())
+        url = f"http://api.openweathermap.org/data/3.0/onecall/timemachine?lat={lat}&lon={lon}&dt={dt}&appid={api_key}&units=metric&lang=ja"
+    else:
+        # Forecast data request
+        url = f"https://api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lon}&exclude=minutely,hourly,current&appid={api_key}&units=metric&lang=ja"
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+        # Find the correct data for the target date
+        weather_data = None
+        if 'daily' in data: # Forecast response
+            for day_data in data['daily']:
+                if date.fromtimestamp(day_data['dt']) == target_date:
+                    weather_data = day_data
+                    break
+        elif 'data' in data: # Historical response
+            weather_data = data['data'][0] # It returns data for the requested timestamp
+
+        if not weather_data:
+            return JsonResponse({'error': '指定された日付のデータが見つかりませんでした。'}, status=404)
+
+        # Map API response to our model fields
+        weather_mapping = {
+            'Clear': 'sunny', 'Clouds': 'cloudy', 'Rain': 'rainy',
+            'Drizzle': 'rainy', 'Thunderstorm': 'rainy', 'Snow': 'rainy',
+            'Mist': 'cloudy', 'Haze': 'cloudy', 'Fog': 'cloudy',
+        }
+
+        # The historical response has a different structure for temp
+        if 'temp' in weather_data and isinstance(weather_data['temp'], dict):
+            max_temp = weather_data['temp']['max']
+            min_temp = weather_data['temp']['min']
+        else:
+            max_temp = weather_data.get('temp')
+            min_temp = weather_data.get('temp')
+
+
+        mapped_data = {
+            'weather': weather_mapping.get(weather_data['weather'][0]['main'], ''),
+            'max_temperature': max_temp,
+            'min_temperature': min_temp,
+            'humidity': weather_data['humidity'],
+            'pressure': weather_data['pressure'],
+        }
+
+        # TODO: Add separate call for Air Pollution API to get PM2.5
+
+        return JsonResponse(mapped_data)
+
+    except requests.exceptions.RequestException as e:
+        return JsonResponse({'error': f'APIの呼び出しに失敗しました: {e}'}, status=500)

--- a/render.yaml
+++ b/render.yaml
@@ -16,5 +16,8 @@ services:
           property: connectionString
       - key: SECRET_KEY
         generateValue: true
+      - key: OPENWEATHER_API_KEY
+        # IMPORTANT: Replace this with your actual API key in the Render dashboard
+        value: "YOUR_API_KEY_HERE"
       - key: WEB_CONCURRENCY
         value: 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,17 @@
 asgiref==3.9.1
+certifi==2025.8.3
+charset-normalizer==3.4.2
 dj-database-url==3.0.1
 Django==5.2.4
 greenlet==3.2.3
 gunicorn==23.0.0
+idna==3.10
 packaging==25.0
 playwright==1.54.0
 psycopg2-binary==2.9.10
 pyee==13.0.0
+requests==2.32.4
 sqlparse==0.5.3
 typing_extensions==4.14.1
+urllib3==2.5.0
 whitenoise==6.9.0


### PR DESCRIPTION
- Adds a button to the data entry form to fetch weather data from the OpenWeatherMap API.
- Implements a new view (`get_weather_data`) that calls the API to get historical or forecast data for a given date.
- Uses JavaScript on the frontend to call the new view and populate the form fields (weather, temperature, humidity, pressure).
- Adds `OPENWEATHER_API_KEY` to `render.yaml` to allow you to securely provide your API key.