### PR TITLE
feat: Replace OpenWeatherMap with Open-Meteo API

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,8 +16,5 @@ services:
           property: connectionString
       - key: SECRET_KEY
         generateValue: true
-      - key: OPENWEATHER_API_KEY
-        # IMPORTANT: Replace this with your actual API key in the Render dashboard
-        value: "YOUR_API_KEY_HERE"
       - key: WEB_CONCURRENCY
         value: 4


### PR DESCRIPTION
- Replaces the weather data provider from OpenWeatherMap to Open-Meteo to remove the need for API key management and credit card registration.
- The `get_weather_data` view is updated to call the Open-Meteo Forecast and Air Quality APIs.
- The new implementation fetches weather, temperature, pressure, humidity, and PM2.5 data.
- Adds a mapping for PM2.5 concentration to the S-D rating scale.
- Removes the `OPENWEATHER_API_KEY` from the `render.yaml` configuration as it is no longer needed.