### PR TITLE
fix: Correctly handle pressure and PM2.5 data

### DIFF
--- a/records/templates/records/record_form.html
+++ b/records/templates/records/record_form.html
@@ -65,9 +65,9 @@
                     document.getElementById('id_max_temperature').value = data.max_temperature || '';
                     document.getElementById('id_min_temperature').value = data.min_temperature || '';
                     document.getElementById('id_humidity').value = data.humidity || '';
-                    // Note: API provides one pressure value, so we set both fields to the same value.
-                    document.getElementById('id_max_pressure').value = data.pressure || '';
-                    document.getElementById('id_min_pressure').value = data.pressure || '';
+                    document.getElementById('id_max_pressure').value = data.max_pressure || '';
+                    document.getElementById('id_min_pressure').value = data.min_pressure || '';
+                    document.getElementById('id_pm25').value = data.pm25 || '';
 
                     statusSpan.textContent = 'データを取得しました。';
                 })

--- a/records/views.py
+++ b/records/views.py
@@ -88,7 +88,7 @@ def get_weather_data(request):
         weather_params = {
             "latitude": lat,
             "longitude": lon,
-            "daily": "weather_code,temperature_2m_max,temperature_2m_min,surface_pressure_mean,relative_humidity_2m_mean",
+            "daily": "weather_code,temperature_2m_max,temperature_2m_min,pressure_msl_max,pressure_msl_min,relative_humidity_2m_mean",
             "timezone": "Asia/Tokyo",
             "start_date": target_date_str,
             "end_date": target_date_str,
@@ -115,21 +115,13 @@ def get_weather_data(request):
         # --- Process and combine data ---
         daily_data = weather_data.get('daily', {})
 
-        # WMO Weather code mapping
         weather_code_mapping = {
-            0: 'sunny',  # Clear sky
-            1: 'sunny',  # Mainly clear
-            2: 'cloudy', # Partly cloudy
-            3: 'cloudy', # Overcast
-            45: 'cloudy',# Fog
-            48: 'cloudy',# Depositing rime fog
-            51: 'rainy', 53: 'rainy', 55: 'rainy', # Drizzle
-            61: 'rainy', 63: 'rainy', 65: 'rainy', # Rain
-            80: 'rainy', 81: 'rainy', 82: 'rainy', # Rain showers
+            0: 'sunny', 1: 'sunny', 2: 'cloudy', 3: 'cloudy', 45: 'cloudy', 48: 'cloudy',
+            51: 'rainy', 53: 'rainy', 55: 'rainy', 61: 'rainy', 63: 'rainy', 65: 'rainy',
+            80: 'rainy', 81: 'rainy', 82: 'rainy',
         }
         weather_code = daily_data.get('weather_code', [None])[0]
 
-        # PM2.5 rating
         pm25_avg = None
         if air_data.get('hourly', {}).get('pm2_5'):
             pm25_values = [v for v in air_data['hourly']['pm2_5'] if v is not None]
@@ -148,8 +140,9 @@ def get_weather_data(request):
             'weather': weather_code_mapping.get(weather_code, ''),
             'max_temperature': daily_data.get('temperature_2m_max', [None])[0],
             'min_temperature': daily_data.get('temperature_2m_min', [None])[0],
+            'max_pressure': daily_data.get('pressure_msl_max', [None])[0],
+            'min_pressure': daily_data.get('pressure_msl_min', [None])[0],
             'humidity': daily_data.get('relative_humidity_2m_mean', [None])[0],
-            'pressure': daily_data.get('surface_pressure_mean', [None])[0],
             'pm25': pm25_rating,
         }
 


### PR DESCRIPTION
- Updates the Open-Meteo API call in `get_weather_data` to request `pressure_msl_max` and `pressure_msl_min` instead of the mean pressure, allowing for correct population of max/min pressure fields.
- Fixes a bug in `record_form.html` where the fetched PM2.5 rating was not being populated into the form field.