### PR TITLE
feat: Implement CSV export functionality

### DIFF
--- a/records/templates/records/record_list.html
+++ b/records/templates/records/record_list.html
@@ -16,7 +16,9 @@
     </ul>
     {% endif %}
 
-    <a href="{% url 'create_record' %}">新しい記録を追加</a>
+    <a href="{% url 'create_record' %}">新しい記録を追加</a> |
+    <a href="{% url 'export_csv' %}">CSV形式でダウンロード</a>
+    <br><br>
     <table border="1">
         <thead>
             <tr>

--- a/records/urls.py
+++ b/records/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('<int:pk>/delete/', views.delete_record, name='delete_record'),
     path('visualize/', views.data_visualization, name='data_visualization'),
     path('api/get-weather/', views.get_weather_data, name='get_weather_data'),
+    path('export/csv/', views.export_csv, name='export_csv'),
 ]


### PR DESCRIPTION
- Adds a new view `export_csv` that generates a CSV file of all `DailyRecord` objects.
- The view uses the `csv` module to write the data, including human-readable values for choice fields.
- Adds a URL pattern for the new view.
- Adds a download link on the record list page.