### PR TITLE
fix: Add UTF-8 BOM to CSV export for Excel compatibility

### DIFF
--- a/records/views.py
+++ b/records/views.py
@@ -159,7 +159,7 @@ def get_weather_data(request):
         return JsonResponse({'error': 'サーバーで予期せぬエラーが発生しました。'}, status=500)
 
 def export_csv(request):
-    response = HttpResponse(content_type='text/csv; charset=utf-8')
+    response = HttpResponse(content_type='text/csv; charset=utf-8-sig')
     response['Content-Disposition'] = 'attachment; filename="daily_records.csv"'
 
     writer = csv.writer(response)


### PR DESCRIPTION
- Changes the response charset for CSV downloads from `utf-8` to `utf-8-sig`.
- This prepends a Byte Order Mark (BOM) to the file, which allows Microsoft Excel to correctly recognize the UTF-8 encoding and display Japanese characters without corruption.