### PR TITLE
perf: Set WEB_CONCURRENCY to 1 to maximize available memory

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -21,4 +21,4 @@ services:
       - key: BASIC_AUTH_PASSWORD
         generateValue: true # Generates a random password, user should set their own
       - key: WEB_CONCURRENCY
-        value: 4
+        value: "1"


### PR DESCRIPTION
- Based on my analysis of the memory usage, I have set WEB_CONCURRENCY to 1 to allocate the maximum available memory on Render's free tier to a single process.
- This is a final attempt to allow the resource-intensive AI analysis page to run without causing an out-of-memory error.